### PR TITLE
feat: support gui colors

### DIFF
--- a/syntax/christmastree.vim
+++ b/syntax/christmastree.vim
@@ -13,17 +13,17 @@ syn match christmastreeFlowerpot /\[_\+\]/
 syn match christmastreeFlowerpot /\\_\+\//
 syn match christmastreeSnow /\*/ containedin=NONE
 
-hi def christmastreeYellow term=NONE ctermfg=226
-hi def christmastreeGreen term=NONE ctermfg=47
-hi def christmastreeRed term=NONE ctermfg=196
-hi def christmastreeBrown term=NONE ctermfg=173
-hi def christmastreeGold term=NONE ctermfg=220
-hi def christmastreeWhite term=NONE ctermfg=254
-hi def christmastreePurple term=NONE ctermfg=147
-hi def christmastreeSkyblue term=NONE ctermfg=117
-hi def christmastreePink term=NONE ctermfg=168
-hi def christmastreeLight term=NONE ctermfg=229
-hi def christmastreeOrange term=NONE ctermfg=208
+hi def christmastreeYellow term=NONE ctermfg=226 guifg=yellow
+hi def christmastreeGreen term=NONE ctermfg=47 guifg=lightgreen
+hi def christmastreeRed term=NONE ctermfg=196 guifg=red
+hi def christmastreeBrown term=NONE ctermfg=173 guifg=#bf8040
+hi def christmastreeGold term=NONE ctermfg=220 guifg=gold
+hi def christmastreeWhite term=NONE ctermfg=254 guifg=white
+hi def christmastreePurple term=NONE ctermfg=147 guifg=purple
+hi def christmastreeSkyblue term=NONE ctermfg=117 guifg=skyblue
+hi def christmastreePink term=NONE ctermfg=168 guifg=pink
+hi def christmastreeLight term=NONE ctermfg=229 guifg=lightyellow
+hi def christmastreeOrange term=NONE ctermfg=208 guifg=orange
 
 hi def link christmastreeStar christmastreeYellow
 hi def link christmastreeLeaves christmastreeGreen


### PR DESCRIPTION
This adds 'guifg' attributes for each highlighting command. In most
cases, I've used the named color that best matches the highlight group
name (e.g., `guifg=green` for christmastreeGreen).

Some caveats:

 * I map "christmastreeLight" to "lightyellow" (to my eyes, it looks
   like this is what cterm=229 is)
 * I map "christmastreeBrown" to a specific hex code, to better match
   the color I see in terminal vim
 * I map "christmastreeGreen" to "lightgreen" because it's a closer
   match to the cterm color than "green"
 * The other cases are not exact matches, but this isn't a big concern,
   since they're just colors for ornaments, which frequently cycle
   colors anyway (and the colors look fine to me at a glance)

guifg attributes are necessary to support gVim as well as terminal vim
with the 'termguicolors' setting enabled (available on vim8 and neovim).

Fixes #1
Test: Manual, compare vim with & without termguicolors, side-by-side