### PR TITLE
fix(swap): open christmastree without a swapfile

### DIFF
--- a/plugin/christmastree.vim
+++ b/plugin/christmastree.vim
@@ -5,8 +5,8 @@ endif
 let s:tree_file = fnamemodify(expand('<sfile>'), ':p:h:h') . '/christmas-tree.txt'
 
 function! s:open() abort
-    execute 'botright vsplit' s:tree_file
-    setlocal readonly
+    execute 'botright vertical sview' s:tree_file
+    setlocal nomodifiable
     wincmd p
 endfunction
 command! -nargs=0 -bar MerryChristmas call <SID>open()


### PR DESCRIPTION
Previously, `:MerryChristmas` would open the Christmas tree file in
read-write mode (which creates a swapfile) and then immediately set
readonly mode. Instead, we should open the file in readonly mode to
begin with using `:sview`.

This also sets `nomodifiable`, since this UI is not intended to be
edited by users.

Fixes #3
Test: Manual - run `:MerryChristmas` from two vim instances, observe no
swap file warning.