### PR TITLE
Adjust how start/stop autocmds are configured

### DIFF
--- a/ftplugin/christmastree.vim
+++ b/ftplugin/christmastree.vim
@@ -51,8 +51,11 @@ function! s:christmas_glitter_stop() abort
 endfunction
 
 if get(g:, 'christmastree_glitter_update', 1)
-    call s:christmas_glitter_start()
-    autocmd BufWipeout <buffer> call <SID>christmas_glitter_stop()
+    augroup ChristmasTreeTimer
+        autocmd!
+        autocmd BufWinEnter <buffer> call <SID>christmas_glitter_start()
+        autocmd BufWinLeave <buffer> call <SID>christmas_glitter_stop()
+    augroup END
 endif
 
 command! -nargs=0 -bar -buffer ChristmasTreeTurnOn call <SID>christmas_glitter_start()


### PR DESCRIPTION
Before this change, the `christmas_glitter_tick()` timer function would
continue looping even if the christmas-tree buffer was not visible but
still loaded. This is not a huge problem since it only runs once per
second, but is still not ideal. This change configures the timer to stop
when the buffer is no longer visible (BufWinLeave) and to resume when
the buffer becomes visible (BufWinEnter).

This also refactors the autocmds into a named augroup. This is probably
not a big issue either, but it makes it easy to clear the group so we
are safe if we somehow execute ftplugin twice for the buffer.

Test: Seems to work on my machine (nvim 0.6). Even if I load the same
buffer into multiple splits, it seems to only have 1 timer going (so all
the splits are synchronized, changing colors once per second as
expected).
Test: move the buffer to the background and call `:hi
christmastreeGlitterLarge` multiple times (over the course of several
seconds), verify the highlight linking remains the same